### PR TITLE
Add pull_request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 11
         uses: actions/setup-java@v1.3.0
         with:


### PR DESCRIPTION
Tested locally with act. Needs Java 11 to build multi-release jar.

```
 $ act pull_request
[Java PR build (gradle)/build] 🚀  Start image=node:12.6-buster-slim
[Java PR build (gradle)/build]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Java PR build (gradle)/build]   🐳  docker cp src=/Users/jkeller/code/newrelic-module-util-java/. dst=/github/workspace
[Java PR build (gradle)/build] ⭐  Run actions/checkout@v2
[Java PR build (gradle)/build]   ✅  Success - actions/checkout@v2
[Java PR build (gradle)/build] ⭐  Run Set up JDK 11
[Java PR build (gradle)/build]   ☁  git clone 'https://github.com/actions/setup-java' # ref=v1.3.0
[Java PR build (gradle)/build]   🐳  docker cp src=/Users/jkeller/.cache/act/actions-setup-java@v1.3.0 dst=/actions/
[Java PR build (gradle)/build]   💬  ##[debug]isExplicit: 
[Java PR build (gradle)/build]   💬  ##[debug]explicit? false
[Java PR build (gradle)/build]   💬  ##[debug]evaluating 0 versions
[Java PR build (gradle)/build]   💬  ##[debug]match not found
[Java PR build (gradle)/build]   💬  ##[debug]Downloading Jdk from Azul
[Java PR build (gradle)/build]   💬  ##[debug]Downloading https://static.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-linux_x64.tar.gz
[Java PR build (gradle)/build]   💬  ##[debug]Downloading /tmp/4a131d7d-2bc9-4d1e-9c2b-8583ca2e7b60
^[[Java PR build (gradle)/build]   💬  ##[debug]download complete
| [command]/bin/tar xzC /tmp/temp_1541277160 -f /tmp/4a131d7d-2bc9-4d1e-9c2b-8583ca2e7b60
[Java PR build (gradle)/build]   💬  ##[debug]jdk extracted to /tmp/temp_1541277160/zulu11.39.15-ca-jdk11.0.7-linux_x64
[Java PR build (gradle)/build]   💬  ##[debug]Caching tool jdk 11.0.7 x64
[Java PR build (gradle)/build]   💬  ##[debug]source dir: /tmp/temp_1541277160/zulu11.39.15-ca-jdk11.0.7-linux_x64
[Java PR build (gradle)/build]   💬  ##[debug]destination /opt/hostedtoolcache/jdk/11.0.7/x64
[Java PR build (gradle)/build]   💬  ##[debug]finished caching tool
[Java PR build (gradle)/build]   ⚙  ::set-env:: JAVA_HOME=/opt/hostedtoolcache/jdk/11.0.7/x64
[Java PR build (gradle)/build]   ⚙  ::set-env:: JAVA_HOME_11.0.7_x64=/opt/hostedtoolcache/jdk/11.0.7/x64
[Java PR build (gradle)/build]   ⚙  ::add-path:: /opt/hostedtoolcache/jdk/11.0.7/x64/bin
[Java PR build (gradle)/build]   ❓  ##[add-matcher]/actions/actions-setup-java@v1.3.0/.github/java.json
| creating settings.xml with server-id: github; environment variables: username=$GITHUB_ACTOR and password=$GITHUB_TOKEN
[Java PR build (gradle)/build]   💬  ##[debug]created directory /github/home/.m2
| writing /github/home/.m2/settings.xml
[Java PR build (gradle)/build]   ✅  Success - Set up JDK 11
[Java PR build (gradle)/build] ⭐  Run Build with Gradle
| Downloading https://services.gradle.org/distributions/gradle-6.3-bin.zip
| .................................................................................................
| 
| Welcome to Gradle 6.3!
| 
| Here are the highlights of this release:
|  - Java 14 support
|  - Improved error messages for unexpected failures
| 
| For more details see https://docs.gradle.org/6.3/release-notes.html
| 
| Starting a Gradle Daemon (subsequent builds will be faster)
<--------<--------<--------<========<--------<--------<==------<==------<=====---<========
| BUILD SUCCESSFUL in 21s
| 3 actionable tasks: 3 executed
| 
| 
[Java PR build (gradle)/build]   ✅  Success - Build with Gradle
```