### PR TITLE
add unnamed module to java.net.http for java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ sourceSets {
             srcDirs = ['src/java9/java']
         }
     }
+    java11 {
+        java {
+            srcDirs = ['src/java11/java']
+        }
+    }
 }
 
 java {
@@ -38,6 +43,12 @@ compileJava9Java {
     targetCompatibility = JavaVersion.VERSION_1_9
 }
 
+// Java 11
+compileJava11Java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 // if you are running gradle with Java 9 or higher, then
 // we know that Java 9's "javac" command supports the --release flag,
 // which supports creating .class files for Java 6 and higher.
@@ -49,6 +60,8 @@ tasks.withType(JavaCompile) {
 dependencies {
     // This allows the java9 sourceSet to compile using classes from the main sourceSet.
     java9Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
+
+    java11Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
 
     // NOTE: This project is extracted into the final newrelic.jar, and only
     //  classes from com.newrelic.** are included. The classes have been written
@@ -62,6 +75,10 @@ jar {
     into('META-INF/versions/9') {
         from sourceSets.java9.output
     }
+    into('META-INF/versions/11') {
+        from sourceSets.java11.output
+    }
+
     manifest.attributes(
             'Multi-Release': 'true'
     )

--- a/src/java11/java/com/newrelic/agent/modules/HttpModuleUtilImpl.java
+++ b/src/java11/java/com/newrelic/agent/modules/HttpModuleUtilImpl.java
@@ -1,0 +1,31 @@
+package com.newrelic.agent.modules;
+
+import java.lang.instrument.Instrumentation;
+import java.net.http.HttpClient;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class HttpModuleUtilImpl implements HttpModuleUtil {
+    /**
+     * Modify the java.net.http module so that it can read from the platform classloader's
+     * unnamed module. The agent http client instrumentation utility classes are
+     * in this specific unnamed module.
+     */
+    @Override
+    public void addReadHttpModule(Instrumentation inst, ClassLoader agentClassLoader) {
+        Module httpClientModule = HttpClient.class.getModule();
+        Module agentUnnamedModule = agentClassLoader.getUnnamedModule();
+        Set<Module> unnamedModule = Set.of(agentUnnamedModule);
+
+        inst.redefineModule(
+                httpClientModule,
+                unnamedModule,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptySet(),
+                Collections.emptyMap()
+        );
+    }
+}

--- a/src/java9/java/com/newrelic/agent/modules/ModuleUtilImpl.java
+++ b/src/java9/java/com/newrelic/agent/modules/ModuleUtilImpl.java
@@ -17,7 +17,7 @@ public class ModuleUtilImpl implements ModuleUtil {
      * can get past the module access controls.
      */
     @Override
-    public void redefineModules(Instrumentation inst, ClassLoader agentClassLoader) {
+    public void redefineJavaBaseModule(Instrumentation inst, ClassLoader agentClassLoader) {
         Module javaBaseModule = Object.class.getModule();
         Module agentModule = agentClassLoader.getUnnamedModule();
         Map<String, Set<Module>> extraOpensAndExports = new HashMap<>();

--- a/src/main/java/com/newrelic/agent/modules/HttpModuleUtil.java
+++ b/src/main/java/com/newrelic/agent/modules/HttpModuleUtil.java
@@ -1,0 +1,13 @@
+package com.newrelic.agent.modules;
+
+import java.lang.instrument.Instrumentation;
+
+public interface HttpModuleUtil {
+    /**
+     * Expands java.net.http module to expose its inner workings to us. The specifics
+     * can be found in the Java {@literal >=} 11 implementation of this class.
+     * @param inst The premain {@link Instrumentation} instance
+     * @param platformClassLoader The platform classloader
+     */
+    void addReadHttpModule(Instrumentation inst, ClassLoader platformClassLoader);
+}

--- a/src/main/java/com/newrelic/agent/modules/HttpModuleUtilImpl.java
+++ b/src/main/java/com/newrelic/agent/modules/HttpModuleUtilImpl.java
@@ -1,0 +1,10 @@
+package com.newrelic.agent.modules;
+
+import java.lang.instrument.Instrumentation;
+
+public class HttpModuleUtilImpl implements HttpModuleUtil {
+    @Override
+    public void addReadHttpModule(Instrumentation inst, ClassLoader platformClassLoader) {
+        //no-op in Java < 11
+    }
+}

--- a/src/main/java/com/newrelic/agent/modules/ModuleUtil.java
+++ b/src/main/java/com/newrelic/agent/modules/ModuleUtil.java
@@ -16,5 +16,5 @@ public interface ModuleUtil {
      * agent classes; it is this classloader's unnamed module that will have
      * access to the necessary packages.
      */
-    void redefineModules(Instrumentation inst, ClassLoader agentClassLoader);
+    void redefineJavaBaseModule(Instrumentation inst, ClassLoader agentClassLoader);
 }

--- a/src/main/java/com/newrelic/agent/modules/ModuleUtilImpl.java
+++ b/src/main/java/com/newrelic/agent/modules/ModuleUtilImpl.java
@@ -13,7 +13,7 @@ public class ModuleUtilImpl implements ModuleUtil {
      * so this is a no-op.
      */
     @Override
-    public void redefineModules(Instrumentation inst, ClassLoader agentClassLoader) {
+    public void redefineJavaBaseModule(Instrumentation inst, ClassLoader agentClassLoader) {
         // no-op in Java < 9.
     }
 }


### PR DESCRIPTION
This will make it easier for customers  to use the Java 11 HttpClient Instrumentation [newrelic/newrelic-java-agent#191](https://github.com/newrelic/newrelic-java-agent/pull/191) . Without this change, the customer would manually need to add `--add-reads java.net.http=ALL-UNNAMED` to their java command so that the Java11 HttpClient instrumentation does not produce module access errors. 

This PR will add the Unnamed module to `java.net.http` when the agent starts up.  Customers will not have to change their java startup command.

I have tested this manually with a local jar as a dependency of the agent.

Once this is merged, I will release a new version and can update/finish PR #191 
